### PR TITLE
Fix broken links on home page

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -129,9 +129,9 @@
     <!-- Call to Action -->
     <div class="cta-section" id="cite">
         <h2 style="color: var(--text-heading); margin-bottom: 25px; transition: color 0.3s ease;">Get Involved</h2>
-        <a href="/papers/" class="cta-button primary">Browse All Papers</a>
-        <a href="/submit/" class="cta-button">Submit a Paper</a>
-        <a href="/cite/" class="cta-button">Cite This Review</a>
+        <a href="/acc-ml-living-review/papers/" class="cta-button primary">Browse All Papers</a>
+        <a href="/acc-ml-living-review/submit/" class="cta-button">Submit a Paper</a>
+        <a href="/acc-ml-living-review/cite/" class="cta-button">Cite This Review</a>
         <a href="{{ .Site.Params.github }}" class="cta-button" target="_blank">View on GitHub</a>
     </div>
 </div>


### PR DESCRIPTION
The "Get Involved" links on the home page were missig the path.

Maybe, one should also adjust the base path in the `config.toml`, but locally I coudn't figure out what it's doing.
```diff
diff --git a/site/config.toml b/site/config.toml
index f4d2b7c..43eb0dd 100644
--- a/site/config.toml
+++ b/site/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://aghribi.github.io/acc-ml-living-review/"
 languageCode = "en-us"
 title = "The AI/ML for particle accelerators living review"
```